### PR TITLE
Use api for structure

### DIFF
--- a/public/about.html
+++ b/public/about.html
@@ -1,8 +1,9 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN"
-   "http://www.w3.org/TR/html4/strict.dtd">
+<!DOCTYPE html>
 <html lang="en">
 <head>
-	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<title>About</title>
 	<link rel="stylesheet" href="css/reader.css" type="text/css" media="screen" charset="utf-8">
 </head>
@@ -10,26 +11,26 @@
     
     <h1>About this site</h1>
     
-    <p>This site shows all the articles from today’s issue of the <a href="http://www.guardian.co.uk/theguardian/all/"><cite>Guardian</cite></a> or, on Sundays, <a href="http://www.guardian.co.uk/theobserver/all/"><cite>Observer</cite></a> newspapers. It is run by <a href="http://www.gyford.com/">Phil Gyford</a> and uses the <a href="http://www.guardian.co.uk/open-platform">Guardian Open Platform</a>. A new issue appears around midnight GMT.</p>
+    <p>This site shows all the articles from today’s issue of the <a href="http://www.guardian.co.uk/theguardian/all/"><cite>Guardian</cite></a> or, on Sundays, <a href="http://www.guardian.co.uk/theobserver/all/"><cite>Observer</cite></a> newspapers. It is run by <a href="http://www.gyford.com/">Phil Gyford</a> and uses the <a href="http://www.guardian.co.uk/open-platform">Guardian Open Platform</a>. A new issue appears around midnight UK time.</p>
     
     <div class="hr"></div><hr />
     
     <p>Navigate the articles using keyboard shortcuts:</p>
     
     <p id="keys">
-        <span id="keys-up">Scroll up: <strong>w</strong> or <strong>k</strong></span>
-        <span id="keys-left">Previous article: <strong>a</strong> or <strong>h</strong> or <strong>&larr;</strong></span>
-        <span id="keys-right">Next article: <strong>d</strong> or <strong>l</strong> or <strong>&rarr;</strong></span>
-        <span id="keys-down">Scroll down: <strong>s</strong> or <strong>j</strong> or <strong>space</strong></span>
+		<span class="keys-key" id="keys-up"><span class="keys-instruction">Scroll up: </span><kbd>w</kbd> or <kbd>k</kbd></span>
+		<span class="keys-key" id="keys-left"><span class="keys-instruction">Previous article: </span><kbd>a</kbd> or <kbd>h</kbd> or <kbd>&larr;</kbd></span>
+		<span class="keys-key" id="keys-right"><span class="keys-instruction">Next article: </span><kbd>d</kbd> or <kbd>l</kbd> or <kbd>&rarr;</kbd></span>
+		<span class="keys-key" id="keys-down"><span class="keys-instruction">Scroll down: </span><kbd>s</kbd> or <kbd>j</kbd> or <kbd>space</kbd></span>
     </p>
     
     <p>Clicking a “scroll down” key at the end of an article will take you to the next.</p>
     
     <p>Pressing Shift with “next”/“previous” keys will move you to the next/previous section.</p>
 
-	<p>Press <strong>v</strong> to open the original version of the current article in a new window.</p>
+	<p>Press <kbd>v</kbd> to open the original version of the current article in a new window.</p>
 
-	<p>Swiping left/right on an iPhone, iPad, etc. will move between articles.</p>
+	<p>Swiping left/right on phone and tables should move between articles.</p>
 
     <div class="hr"></div><hr />
 

--- a/public/css/reader.css
+++ b/public/css/reader.css
@@ -458,18 +458,19 @@ body#about-page {
 #about-page p {
 	margin-bottom: 1.5em;
 }
-#about-page #keys {
-	width: 500px;
-	margin-left: auto;
-	margin-right: auto;
+#about-page kbd {
+	font-weight: bold;
 }
-#about-page #keys span {
+#about-page #keys .keys-key {
 	display: block;
 	margin-bottom: 0.5em;
+	text-align: center;
+}
+#about-page #keys .keys-instruction {
+	display: block;
 }
 #about-page #keys-up,
 #about-page #keys-down {
-	text-align: center;
 	clear: both;
 }
 #about-page #keys-left {
@@ -477,6 +478,18 @@ body#about-page {
 }
 #about-page #keys-right {
 	float: right;
+}
+
+
+@media (min-width: 560px) {
+	#about-page #keys {
+		width: 500px;
+		margin-left: auto;
+		margin-right: auto;
+	}
+	#about-page #keys .keys-instruction {
+		display: inline;
+	}
 }
 
 

--- a/public/css/reader.css
+++ b/public/css/reader.css
@@ -257,35 +257,44 @@ https://github.com/guardian/frontend/tree/master/static/src/stylesheets/module/c
 	clear: left;
 	margin-bottom: 0.667em;
 }
+
 .page .byline {
 	border-top: 1px solid #ddd;
 	border-bottom: 1px solid #ddd;
-	margin-bottom: 1.8em;
-	padding: 0.4em 0 0.4em 0;
+	margin-bottom: 1.125em;
+	padding: 0.25em 0 0.25em 0;
 	font-family: "Lucida Sans", "Lucida Grande", "Lucida Sans Unicode", sans-serif;
 	color: #666;
 	line-height: 1.2em;
 }
-.standfirst {
+.page .byline p {
+	margin: 0;
+}
+
+.page .has-contributor .byline {
 	font-weight: bold;
+}
+.page .standfirst {
+	font-weight: bold;
+	-webkit-hyphens: auto;
+	-moz-hyphens: auto;
+	hyphens: auto;
 }
 .page .body {
 	float: left;
 	width: 530px;
-	/* These probably do nothing at the moment: */
-	hyphens: auto;
 	-webkit-hyphens: auto;
 	-moz-hyphens: auto;
+	hyphens: auto;
 }
 .page .body .no-rights,
 .page .body .no-body {
 	font-style: italic;
 }
-.page .body .thumbnail {
+.page .thumbnail {
 	float: right;
 	margin: 0.3em 0 0.5em 10px;
 	width: 140px;
-	height: 84px;
 }
 .page .body h2 {
 	font-weight: bold;
@@ -311,6 +320,7 @@ div.gu_advert {
 	margin: 1em auto;
 	/* To help keep the figcaption to the right width (see below). */
 	display: table;
+	clear: both;
 }
 .page figure img,
 .page figure video {
@@ -554,7 +564,7 @@ body#about-page {
  */
 #title,
 #progress span,
-.page p.byline,
+.page .byline p,
 .page figure figcaption,
 .page .footer p,
 #about-page .close,

--- a/public/css/reader.css
+++ b/public/css/reader.css
@@ -231,15 +231,21 @@ div.hr {
 	padding-top: 1em;
 }
 
-.section-news .meta { border-color: #D61D00; color: #D61D00; }
-.section-sport .meta { border-color: #008000; color: #008000; }
-.section-comment .meta { border-color: #0061A6; color: #0061A6; }
-.section-culture .meta { border-color: #D1008B; color: #D1008B; }
-.section-business .meta { border-color: #3246AB; color: #3246AB; }
-.section-money .meta { border-color: #8F1AB6; color: #8F1AB6; }
-.section-life .meta { border-color: #AD532F; color: #AD532F; }
-.section-travel .meta { border-color: #066EC9; color: #066EC9; }
-.section-environment .meta { border-color: #4A7801; color: #4A7801; }
+/* List of tones:
+https://github.com/guardian/frontend/tree/master/static/src/stylesheets/module/content/tones */
+.tone-analysis .meta		{ border-color: #005689; color: #005689; }
+.tone-comment .meta			{ border-color: #e6711b; color: #e6711b; }
+.tone-dead .meta			{ border-color: #b51800; color: #b51800; }
+.tone-editorial .meta		{ border-color: #005689; color: #005689; }
+.tone-feature .meta			{ border-color: #951c55; color: #951c55; }
+.tone-letters .meta			{ border-color: #e6711b; color: #e6711b; }
+.tone-live .meta			{ border-color: #b51800; color: #b51800; }
+.tone-media .meta			{ border-color: #333333; color: #333333; }
+.tone-news .meta			{ border-color: #005689; color: #005689; }
+.tone-review .meta			{ border-color: #615b52; color: #615b52; }
+.tone-special-report .meta	{ border-color: #63717a; color: #63717a; }
+
+.tone-default .meta			{ border-color: #005689; color: #005689; }
 
 .page .meta .publication {
 	display: none;

--- a/public/index.html
+++ b/public/index.html
@@ -1,15 +1,15 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN"
-   "http://www.w3.org/TR/html4/strict.dtd">
+<!DOCTYPE html>
 <html lang="en">
-<head>
-	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0" />
 	<title>Today's Paper</title>
 	<link rel="stylesheet" href="css/reader.css?v=7" type="text/css" media="screen" charset="utf-8">
 	<!--[if IE 6]>
 		<link rel="stylesheet" href="css/ie6.css" type="text/css" media="screen" charset="utf-8">
 	<![endif]-->
 	
-	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0" />
 	<meta name="apple-mobile-web-app-capable" content="yes" />
 	<link rel="apple-touch-icon" href="img/apple-touch-icon.png" />
 	<link rel="shortcut icon" href="img/favicon.ico" />

--- a/public/index.html
+++ b/public/index.html
@@ -27,7 +27,9 @@
 <body>
 	<div id="wrapper">
 		
-		<p class="alert">The site is back, but not yet complete. <a href="http://www.gyford.com/phil/writing/2015/12/14/todays_guardian_1.php">Read more.</a> &nbsp; (<a href="#" title="Hide this message" class="alert-close">Hide</a>)</p>
+		<!--
+	  	<p class="alert">The site is back, but not yet complete. <a href="http://www.gyford.com/phil/writing/2015/12/14/todays_guardian_1.php">Read more.</a> &nbsp; (<a href="#" title="Hide this message" class="alert-close">Hide</a>)</p>
+		-->
 		
 		<div id="main" class="clearfix">
 			<div id="title" class="clearfix">

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ beautifulsoup4==4.4.1
 Jinja2==2.8
 MarkupSafe==0.23
 python-dateutil==2.4.2
+pytz==2015.7
 requests==2.5.1
 six==1.10.0
 smartypants==1.8.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,8 @@
 beautifulsoup4==4.4.1
+Jinja2==2.8
+MarkupSafe==0.23
 python-dateutil==2.4.2
 requests==2.5.1
 six==1.10.0
 smartypants==1.8.6
+typogrify==2.0.7

--- a/scripts/scraper.py
+++ b/scripts/scraper.py
@@ -257,6 +257,7 @@ class GuardianGrabber:
             raise ScraperError("Error when fetching data from API.")
 
         for article in fetched_articles:
+            # We'll put any tags we want to keep in article itself:
             tags = article['tags']
             del article['tags']
 
@@ -269,12 +270,15 @@ class GuardianGrabber:
                 continue
 
             # Just get the dicts for book and book_section out of the tags list.
-            book = next((tag for tag in tags if tag['type'] == 'newspaper-book'), {})
-            book_section = next((tag for tag in tags if tag['type'] == 'newspaper-book-section'), {})
+            book = next((tag for tag in tags if tag['type'] == 'newspaper-book'), None)
+            book_section = next((tag for tag in tags if tag['type'] == 'newspaper-book-section'), None)
+            # There might be more than contributor; we're only using one:
+            contributor = next((tag for tag in tags if tag['type'] == 'contributor'), None)
 
             # Save these in easy to get places for the template:
             article[u'newspaperBook'] = book
             article[u'newspaperBookSection'] = book_section
+            article[u'contributor'] = contributor
 
             article[u'tone'] = self.get_tone(tags)
 
@@ -402,7 +406,7 @@ class GuardianGrabber:
             'format': 'json',
             'show-fields': 'body,byline,headline,newspaperPageNumber,publication,shortUrl,standfirst,thumbnail,wordcount',
             'show-elements': 'all',
-            'show-tags': 'newspaper-book-section,newspaper-book,tone',
+            'show-tags': 'contributor,newspaper-book,newspaper-book-section,tone',
             # Get the articles from today's edition:
             'use-date': 'newspaper-edition',
             'from-date': self.issue_date.strftime("%Y-%m-%d"),

--- a/scripts/scraper.py
+++ b/scripts/scraper.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 import ConfigParser
 import datetime
 import dateutil.parser
@@ -17,9 +19,9 @@ from bs4 import BeautifulSoup
 
 
 class GuardianGrabber:
-    
+
     def __init__(self):
-        
+
         self.load_config()
         
         
@@ -29,20 +31,27 @@ class GuardianGrabber:
         # First, variables which are set here, not in the config file.
         
         # The array we'll store all the data about today's issue, in this format:
+        #
         # {
         #     'meta': {
         #         'max_words': 2340,
         #         'paper_name': 'observer'
         #     },
-        #     'sections': [
+        #     'books': [
         #         {
-        #             'meta': {'url':'http...', 'title':'Main section'},
-        #             'links': [{
+        #             'meta': {
+        #                   'id': '',
+        #                   'webUrl': 'http...',
+        #                   'webTitle':'Main section',
+        #                   ...},
+        #             'articles': [{
         #                   'id': 'world/gallery/2010/jul/07/spain-spain',
         #                   'path': '/world/gallery/2010/jul/07/spain-spain',
         #                   'title': 'Article title...',
         #                   'file': 'spain-spain.html',
-        #                   'words': 374
+        #                   'words': 374,
+        #                   'newspaperPageNumber': 34,
+        #                   'newspaperBookSection': {'id':'','title':'', ...}
         #               }, {}, {}]
         #         },
         #         {}
@@ -52,12 +61,26 @@ class GuardianGrabber:
             'meta': {
                 'max_words': 0
             },
-            'sections': []
+            'books': []
         }
+
+        # Temporary place for what will go in self.contents['books'].
+        # In this case it's structured like:
+        # {
+        #   'theguardian/sport': {
+        #       'meta': {...},
+        #       'articles': [{...}, {...}, ...],
+        #   },
+        #   ...
+        # }
+        #
+        # Then, after fetching we'll put all the values from this into
+        # self.contents['books'] in the correct order.
+        self.fetched_books = {}
         
         # This will be set in get_list_of_articles() depending on what issue we're 
         # etching. A datetime object.
-        self.issue_date = ''
+        self.issue_date = None
         
         # Will be set in start() to a path of self.archive_dir plus self.issue_date
         self.issue_archive_dir = ''
@@ -73,33 +96,11 @@ class GuardianGrabber:
         # or 'observer'.
         self.paper_name = ''
         
-        
-        # Mapping the sectionId of a story to the (smaller number) of different
-        # coloured sections.
-        self.section_ids = {
-            'artanddesign':     'culture',
-            'books':            'culture',
-            'business':         'business',
-            'commentisfree':    'comment',
-            'education':        'news',
-            'environment':      'environment',
-            'film':             'culture',
-            'football':         'sport',
-            'law':              'news',
-            'lifeandstyle':     'lifeandstyle',
-            'media':            'news',
-            'music':            'culture',
-            'politics':         'news',
-            'science':          'news',
-            'society':          'news',
-            'sport':            'sport',
-            'stage':            'culture',
-            'technology':       'news',
-            'theguardian':      'news',
-            'tv-and-radio':     'culture',
-            'uk':               'news',
-            'world':            'news',
-        }
+        # The 'books' are like 'Main section' or 'The Guide'.
+        self.books = {}
+
+        # 'book_sections' are like 'Film & music reviews' or 'Financial'.
+        self.book_sections = {}
 
         # Will be the lockfile we check to make sure this script doesn't run
         # multiple times.
@@ -168,8 +169,8 @@ class GuardianGrabber:
         self.checkForOldProcesses()
         self.makeLockfile()
         
-        # Populate self.contents.
-        self.get_list_of_articles()
+        # Sets the date and paper (guardian or observer).
+        self.set_issue_date()
         
         if self.issue_date != '':
             self.issue_archive_dir = self.archive_dir + self.issue_date.strftime("%Y-%m-%d") + '/'
@@ -181,7 +182,9 @@ class GuardianGrabber:
             os.makedirs(self.issue_archive_dir)
         
         # Get all of today's articles and save HTML versions to disk.
-        self.fetch_all_articles()
+        self.fetch_articles()
+
+        self.sort_articles()
          
         # Delete the day-before-yesterday's files.
         # (Not yesterday's, just in case someone is currently viewing them.)
@@ -201,84 +204,83 @@ class GuardianGrabber:
         self.removeLockfile()
         
 
-    def get_list_of_articles(self):
-        """
-        Fetches all the information today's paper, including section names and
-        the list of links for every article within each section.
-        """
+    #def get_list_of_articles(self):
+        #"""
+        #Fetches all the information today's paper, including section names and
+        #the list of links for every article within each section.
+        #"""
         
-        soup = self.find_todays_content()
+        #soup = self.find_todays_content()
         
-        # Get each of the section headings (eg, 'Main section', 'Sport', 'G2').
-        sections = soup.findAll('section')
+        ## Get each of the section headings (eg, 'Main section', 'Sport', 'G2').
+        #sections = soup.findAll('section')
         
-        for section in sections:
-            # Get the section title and link.
-            title = section.find('div', {'class': 'fc-container__header__title'})
-            try:
-                section_url = title.find('a').get('href')
-                section_title = title.find('a').string
-            except AttributeError:
-                # 'front page' has no <a> or link:
-                section_url = ''
-                section_title = title.find('span').string
+        #for section in sections:
+            ## Get the section title and link.
+            #title = section.find('div', {'class': 'fc-container__header__title'})
+            #try:
+                #section_url = title.find('a').get('href')
+                #section_title = title.find('a').string
+            #except AttributeError:
+                ## 'front page' has no <a> or link:
+                #section_url = ''
+                #section_title = title.find('span').string
 
-            # Set up the structure in which we'll store info about this section.
-            new_section = {
-                'meta': {
-                    'url': section_url,
-                    'title': section_title.strip()
-                }, 
-                'links':[]
-            }
+            ## Set up the structure in which we'll store info about this section.
+            #new_section = {
+                #'meta': {
+                    #'webUrl': section_url,
+                    #'webTitle': section_title.strip()
+                #}, 
+                #'articles':[]
+            #}
             
-            # Get all the links for this section, and add to new_section['links]
-            article_links = section.findNext('ul', {'class': 'fc-slice'}).findAll('a', {'class': 'fc-item__link'})
-            for a in article_links:
-                article_url = a.get('href', '')
-                # We just store the absolute path, not the full URL.
-                o = urlparse.urlparse(article_url)
-                new_section['links'].append({
-                    'path': o.path,
-                    # We also store the title here, rather than use the one from the
-                    # API, in case we fail to fetch the page from the API - we'll
-                    # still want to display the title in the article's page.
-                    'title': a.get_text().strip()
-                })
+            ## Get all the links for this section, and add to new_section['articles]
+            #article_links = section.findNext('ul', {'class': 'fc-slice'}).findAll('a', {'class': 'fc-item__link'})
+            #for a in article_links:
+                #article_url = a.get('href', '')
+                ## We just store the absolute path, not the full URL.
+                #o = urlparse.urlparse(article_url)
+                #new_section['articles'].append({
+                    #'path': o.path,
+                    ## We also store the title here, rather than use the one from the
+                    ## API, in case we fail to fetch the page from the API - we'll
+                    ## still want to display the title in the article's page.
+                    #'title': a.get_text().strip()
+                #})
             
-            # Add this section to the contents.
-            self.contents['sections'].append(new_section)
+            ## Add this section to the contents.
+            #self.contents['sections'].append(new_section)
 
 
-        # TODO: REMOVE THIS
-        # Because the page we scrape splits stuff into lots of little
-        # sections, we're going to smush it all together into one big
-        # 'Main section' section here:
+        ## TODO: REMOVE THIS
+        ## Because the page we scrape splits stuff into lots of little
+        ## sections, we're going to smush it all together into one big
+        ## 'Main section' section here:
 
-        # Get the current sections:
-        sections = self.contents['sections']
+        ## Get the current sections:
+        #sections = self.contents['sections']
 
-        # Remake the array:
-        self.contents['sections'] = [
-            {
-                'meta': {
-                    'url': '',
-                    'title': 'Main section'
-                }, 
-                'links':[]
-            }
-        ]
-        # Recreate it:
-        for section in sections:
-            for link in section['links']:
-                self.contents['sections'][0]['links'].append(link)
+        ## Remake the array:
+        #self.contents['sections'] = [
+            #{
+                #'meta': {
+                    #'webUrl': '',
+                    #'webTitle': 'Main section'
+                #}, 
+                #'articles':[]
+            #}
+        #]
+        ## Recreate it:
+        #for section in sections:
+            #for link in section['articles']:
+                #self.contents['sections'][0]['articles'].append(link)
     
     
-    def find_todays_content(self):
+    def set_issue_date(self):
         """
         Works out what date's paper we're getting.
-        Sets self.issue_date and self.paper_name, and returns a Beautiful Soup object
-        of the content of the page for the paper.
+        Sets self.issue_date and self.paper_name.
         """
         # Close enough to UK time. Can't work out how to get GMT/BST appropriately.
         date_today = datetime.datetime.utcnow()
@@ -298,9 +300,10 @@ class GuardianGrabber:
         # Monday and we've fetched the Guardian's current contents but it's
         # Saturday's. So we need to try again, and fetch Sunday's Observer instead.
         if date_diff.days > 1:
-            print "Difference is more than one day."
+
             date_yesterday = date_today - datetime.timedelta(1)
-            print "Trying "+date_yesterday.strftime('%Y-%m-%d')
+            self.message('Setting issue date: Difference is more than one day.')
+            self.message("Trying %s." % date_yesterday.strftime('%Y-%m-%d'))
             soup = BeautifulSoup( self.fetch_page( self.paper_url(date_yesterday) ), 'html.parser' )
             
             if date_yesterday != self.scrape_print_date(soup):
@@ -313,7 +316,7 @@ class GuardianGrabber:
         else:
             self.paper_name = self.contents['meta']['paper_name'] = 'guardian'
         
-        return soup
+        return True
         
     
     def scrape_print_date(self, soup):
@@ -339,110 +342,249 @@ class GuardianGrabber:
             return self.source_urls['guardian']   # Monday to Saturday
         
         
-    def fetch_all_articles(self):
+    def fetch_articles(self, page=1):
         """
         Fetches all of the contents of the articles from the API and saves the
         HTMLised version to disk.
         """
-        
+
+        max_articles_to_fetch = 200
+
+        fetched_articles = self.fetch_page_of_articles(page=page,
+                                                page_size=max_articles_to_fetch)
+
+        # Will have keys of books, eg 'theguardian/mainsection',
+        # and values will be a list of dicts. Each dict an article.
+        articles = {}
+
+        if fetched_articles == False:
+            raise ScraperError("Error when fetching data from API.")
+
+        for article in fetched_articles:
+            tags = article['tags']
+
+            if len(tags) == 0:
+                self.message("%s has no tags; unable to put into section." % article['id'])
+                continue
+
+            if u'newspaperPageNumber' not in article[u'fields']:
+                self.message("%s has no page number; unable to put into section." % article['id'])
+                continue
+
+            # Just get the dicts for book and book_section out of the tags list.
+            book = next((tag for tag in article['tags'] if tag['type'] == 'newspaper-book'), {})
+            book_section = next((tag for tag in article['tags'] if tag['type'] == 'newspaper-book-section'), {})
+
+            # Save some of the book section in the article for use in front end.
+            article[u'newspaperBookSection'] = {
+                u'id':       book_section['id'],
+                u'title':    book_section['webTitle'],
+                u'url':      book_section['webUrl'],
+            }
+
+            if book['id'] not in self.fetched_books:
+                self.fetched_books[ book['id'] ] = {
+                    u'meta': book,
+                    u'articles': [],
+                }
+
+            # Make page number into an int.
+            article[u'fields'][u'newspaperPageNumber'] = int(article[u'fields'][u'newspaperPageNumber'])
+
+            # Make wordcount int, and increase issue's max wordcount if appropriate.
+            article[u'fields'][u'wordcount'] = int(article[u'fields'][u'wordcount'])
+            words = article[u'fields'][u'wordcount']
+            if words > self.contents[u'meta'][u'max_words']:
+                 self.contents[u'meta'][u'max_words'] = words
+            
+            # Save file and store its filename:
+            article[u'file'] = self.save_article_html(article)
+
+            self.fetched_books[ book['id'] ]['articles'].append(article)
+
+        if len(fetched_articles) >= max_articles_to_fetch:
+            # We fetched the maximum, so there might be another page.
+            # Call this same method again:
+            # Pause, be nice.
+            time.sleep(1)
+            self.fetch_articles(page=page+1)
+
+    def sort_articles(self):
+        """Puts data from self.fetched_books in the correct order and format,
+        and puts them into the self.content['books'] list.
+        self.fetched_books is like:
+            {
+                'theguardian/mainsection': {
+                    'meta': {...},
+                    'articles': [...],
+                },
+                'theguardian/sport': {
+                    ...
+                },
+                ...
+            }
+
+        So, we need to take the value dicts out of there and put them in
+        self.content['books'] in the correct order.
+        And sort the articles in each section by page number.
+        """
+
+        # The initial known books of each day's newspaper, in order:
+        start_orders = {
+            'weekday': [
+                'theguardian/mainsection',
+                'theguardian/g2',
+            ],
+            'saturday': [
+                'theguardian/mainsection',
+                'theguardian/theguide',
+                'theguardian/guardianreview',
+                'theguardian/weekend',
+                'theguardian/travel',
+                'theguardian/cook',
+                'theguardian/family',
+            ],
+            'sunday': [
+                'theobserver/news',
+                'theobserver/review',
+                'theobserver/magazine',
+            ]
+        }
+
+        # Get today's initial books, and also the sport section.
+        if self.paper_name == 'observer':
+            start_order = start_orders['sunday']
+            sport_id = 'theobserver/sport'
+
+        elif self.issue_date.weekday() == 5:
+            start_order = start_orders['saturday']
+            sport_id = 'theguardian/sport'
+
+        else:
+            start_order = start_orders['weekday']
+            sport_id = 'theguardian/sport'
+    
+        # We'll put the initial books in `start`.
+        # And the sport book in `end`.
+        # And any others - new books or special one-offs - in `middle`.
+        start = []
+        middle = []
+        end = []
+
+        for book in start_order:
+            if book in self.fetched_books:
+                start.append(self.fetched_books.pop(book))
+
+        if sport_id in self.fetched_books:
+            end.append(self.fetched_books.pop(sport_id))
+
+        for book, bookdata in self.fetched_books.iteritems():
+            middle.append(bookdata)
+
+        # Put all the books together in the correct order.
+        # self.contents['books'] is now a list of dicts, one dict per book.
+        # Each book dict has 'meta' and 'articles' keys.
+        self.contents['books'] = start + middle + end
+
+        # Sort the articles within each book:
+        for book in self.contents['books']:
+            book['articles'] = sorted(book['articles'], key=lambda k: k['fields']['newspaperPageNumber'])
+
+
+    def fetch_page_of_articles(self, page=1, page_size=200):
+        """Fetches a single set of articles from today's issue.
+        Returns a list of dicts, each dict an article's data.
+        Or False if there was an error.
+        """
+
+        api_url = 'http://content.guardianapis.com/search'
+
         url_args = {
+            'page': page,
+            'page-size': page_size,
             'api-key': self.guardian_api_key,
             'format': 'json',
-            'show-fields': 'body,byline,headline,publication,shortUrl,standfirst,thumbnail',
-            'show-factboxes': 'all',
+            'show-fields': 'body,byline,headline,newspaperPageNumber,publication,shortUrl,standfirst,thumbnail,wordcount',
+            'show-elements': 'all',
+            'show-tags': 'newspaper-book-section,newspaper-book',
+            # Get the articles from today's edition:
+            'use-date': 'newspaper-edition',
+            'from-date': self.issue_date.strftime("%Y-%m-%d"),
+            'to-date': self.issue_date.strftime("%Y-%m-%d"),
+            # The most we can fetch per page:
         }
-        
-        for section_index, section in enumerate(self.contents['sections']):
-            for link_index, link in enumerate(section['links']):
-                article_url = 'http://content.guardianapis.com' + link['path']
-                
-                self.message('Fetching JSON: ' + article_url)
 
-                error_message = ''
-                
-                try:
-                    response = requests.get(article_url, params=url_args,
-                                            timeout=10)
-                except requests.exceptions.ConnectionError as e:
-                    error_message = "Can't connect to domain."
-                except requests.exceptions.ConnectTimeout as e:
-                    error_message = "Connection timed out."
-                except requests.exceptions.ReadTimeout as e:
-                    error_message = "Read timed out."
+        self.message('Fetching page %s of up to %s articles.' % (page, page_size))
 
-                try:
-                    response.raise_for_status()
-                except requests.exceptions.HTTPError as e:
-                    error_message = "HTTP Error: %s" % response.status_code
+        error_message = ''
 
-                if error_message:
-                    if response.status_code == 403:
-                        error_message = "This article can only be read on theGuardian.com due to rights issues."
-                    elif response.status_code == 404:
-                        error_message = "This article was missing when we tried to fetch it."
-                    self.message(error_message)
-                    # Fake a JSON structure, so that we still have a page for this
-                    # story.
-                    result = {
-                        'response': {
-                            'content': {
-                                'id': link['path'],
-                                'webTitle': link['title'],
-                                'webUrl': 'http://www.theguardian.com' + link['path'],
-                                'fields': {
-                                    'headline': link['title'],
-                                    'body': '<div class="error"><p>'+error_message+'</p><p><a href="http://www.theguardian.com'+link['path']+'">View on theGuardian.com</a></p></div>'
-                                }
-                            }
-                        }
-                    }
-                    
-                else:
-                    # We got a pagea successfully.
-                    result = response.json()
-                
-                html = self.make_article_html(result['response']['content'])
-                
-                # Get the last part of the article's URL
-                # eg 'trident-savings-nuclear-deterrent' from
-                # '/uk/2010/may/19/trident-savings-nuclear-deterrent'
-                match_filename = re.compile(r'/([^/]*)$')
-                filename = match_filename.search(link['path']).groups()[0] + '.html'
-                self.contents['sections'][section_index]['links'][link_index]['file'] = filename
-                self.contents['sections'][section_index]['links'][link_index]['id'] = result['response']['content']['id']
-                
-                if 'body' in result['response']['content']['fields']:
-                    [words, lines] = self.count_words(result['response']['content']['fields']['body'])
-                    self.contents['sections'][section_index]['links'][link_index]['words'] = words
-                    if words > self.contents['meta']['max_words']:
-                        self.contents['meta']['max_words'] = words
-                else:
-                    self.contents['sections'][section_index]['links'][link_index]['words'] = 0
-                
-                try:
-                    article_file = open(self.issue_archive_dir + filename, 'w')
-                    try:
-                        article_file.write(html.encode('utf-8'))
-                    finally:
-                        article_file.close()
-                except IOError:
-                    raise ScraperError("IOError when writing " + self.issue_archive_dir + filename)
-                
-                # Pause, be nice.
-                time.sleep(0.5)
-        
-            
-        
+        try:
+            response = requests.get(api_url, params=url_args, timeout=20)
+        except requests.exceptions.ConnectionError as e:
+            error_message = "Can't connect to domain."
+        except requests.exceptions.ConnectTimeout as e:
+            error_message = "Connection timed out."
+        except requests.exceptions.ReadTimeout as e:
+            error_message = "Read timed out."
+
+        try:
+            response.raise_for_status()
+        except requests.exceptions.HTTPError as e:
+            error_message = "HTTP Error: %s" % response.status_code
+
+        if error_message == '':
+            # All good so far. Check the returned data.
+            data = response.json()
+            if 'response' in data and 'status' in data['response'] and 'results' in data['response']:
+                if data['response']['status'] != 'ok':
+                    error_message = "The API returned the status '%s'" % data['response']['ok']
+            else:
+                error_message = "The returned data was not the expected format."
+
+        if error_message == '':
+            # Still OK!
+            articles = data['response']['results']
+            self.message("Received %s articles." % len(articles))
+            return articles
+        else:
+            self.message("ERROR: %s" % error_message)
+            return False
+
+    def save_article_html(self, article):
+        """Makes the HTML for the article and saves it to a file.
+        article is all the article's data from the API.
+        Returns the filename.
+        """
+        html = self.make_article_html(article)
+
+        # eg, 'society_2015_dec_11_barbro-loader-obituary.html'
+        filename = '%s.%s' % (article['id'].replace('/', '_'), 'html')
+
+        try:
+            article_file = open(self.issue_archive_dir + filename, 'w')
+            try:
+                article_file.write(html.encode('utf-8'))
+            finally:
+                article_file.close()
+        except IOError:
+            raise ScraperError(
+                    "IOError when writing " + self.issue_archive_dir + filename)
+
+        return filename
+
     def make_article_html(self, content):
         """
         Takes the content dictionary from the Guardian Item API call and returns a
         simple HTML version of it.
         """
-        
-        if 'sectionId' in content and content['sectionId'] in self.section_ids:
-            html = "<div class=\"section-" + self.section_ids[content['sectionId']] + "\">\n"
-        else:
-            html = "<div class=\"section-default\">\n"
+
+        # TODO: Add colours.
+        #if 'sectionId' in content and content['sectionId'] in self.section_ids:
+            #html = "<div class=\"section-" + self.section_ids[content['sectionId']] + "\">\n"
+        #else:
+            #html = "<div class=\"section-default\">\n"
+        html = "<div class=\"section-default\">\n"
+
 
         html += "<div class=\"meta\">\n"
 
@@ -451,58 +593,58 @@ class GuardianGrabber:
 
         # Something like 'Guardian. Wednesday 26 May 2010'.
         #html += '<p class="publication">The ' + self.paper_name.title() + '. ' + self.issue_date.strftime("%A %e %B %Y") + "</p>\n"
-    
+
         if 'sectionName' in content:
             html += '<p class="section">' + content['sectionName'] + "</p>\n"
-                
+
         html += "</div>\n"
-        
+
         if 'headline' in content['fields']:
             html += '<div class="headline"><h2>' + content['fields']['headline'] + "</h2></div>\n"
-        
+
         html += "<div class=\"intro\">\n"
-        
+
         if 'byline' in content['fields']:
             html += '<p class="byline">' + content['fields']['byline'] + "</p>\n"
-        
+
         if 'standfirst' in content['fields']:
             html += '<p class="standfirst">' + content['fields']['standfirst'] + "</p>\n"
-        
+
         html += "</div>\n"
-        
+
         html += '<div class="body">'
-        
+
         if 'thumbnail' in content['fields']:
             html += '<img class="thumbnail" alt="Thumbnail" src="' + content['fields']['thumbnail'] + "\" />\n"
-        
+
         if 'body' in content['fields']:
             if content['fields']['body'] == '<!-- Redistribution rights for this field are unavailable -->':
                 # We link this link to the easier-to-read print version.
                 html += '<p class="no-rights">Redistribution rights for the article body are unavailable. <a class="see-original" href="' + content['webUrl'] + '/print?mobile-redirect=false">See original.</a></p>'
             else:
-                
+
                 # Get rid of the empty <p> tags that are sometimes in articles, then add to html.
-                remove_blanks = re.compile(r'<p></p>')                
+                remove_blanks = re.compile(r'<p></p>')
                 html += remove_blanks.sub('', content['fields']['body'])
         else:
             html+= '<p class="no-body">No body text available</p>'
-        
+
         html +=  "</div>\n"
-        
+
         html += "<div class=\"footer\">\n"
-        
+
         if 'webUrl' in content:
             html += '<p class="original"><span>Original: </span><a href="' + content['webUrl'] + '">' + content['webUrl'] + "</a></p>\n"
-            
+
         if 'shortUrl' in content['fields']:
             html += '<p class="share"><span>Share: </span><input type="text" value="' + content['fields']['shortUrl'] + "\" /></p>\n";
-        
+
         html += "</div>\n</div>\n"
-        
+
         html = self.prettify_text( html );
         return html
-    
-    
+
+
     def prettify_text(self, text):
         """
         Make text more nicerer. Run it through SmartyPants and Widont.
@@ -510,15 +652,15 @@ class GuardianGrabber:
         text = self.widont(text)
         text = smartypants.smartypants(text)
         return text
-        
-        
+
+
     def widont(self, text):
         """From Typogrify http://code.google.com/p/typogrify/
         The only difference is that we also match line endings before a <br />.
         Comments from the original code:
-        
+
         Replaces the space between the last two words in a string with ``&nbsp;``
-        Works in these block tags ``(h1-h6, p, li, dd, dt)`` and also accounts for 
+        Works in these block tags ``(h1-h6, p, li, dd, dt)`` and also accounts for
         potential closing inline elements ``a, em, strong, span, b, i``
 
         >>> widont('A very simple test')
@@ -544,7 +686,7 @@ class GuardianGrabber:
         u'<h1><a href="#">In a link</a> followed by other&nbsp;text</h1>'
 
         Empty HTMLs shouldn't error
-        >>> widont('<h1><a href="#"></a></h1>') 
+        >>> widont('<h1><a href="#"></a></h1>')
         u'<h1><a href="#"></a></h1>'
 
         >>> widont('<div>Divs get no love!</div>')
@@ -559,18 +701,18 @@ class GuardianGrabber:
         widont_finder = re.compile(r"""((?:</?(?:a|em|span|strong|i|b)[^>]*>)|[^<>\s]) # must be proceeded by an approved inline opening or closing tag or a nontag/nonspace
                                        \s+                                             # the space to replace
                                        ([^<>\s]+                                       # must be flollowed by non-tag non-space characters
-                                       \s*                                             # optional white space! 
+                                       \s*                                             # optional white space!
                                        (</(a|em|span|strong|i|b)>\s*)*                 # optional closing inline tags with optional white space after each
                                        ((</(p|h[1-6]|li|dt|dd)>|<br\s?/?>)|$))                   # end with a closing p, h1-6, li or the end of the string
                                        """, re.VERBOSE)
         output = widont_finder.sub(r'\1&nbsp;\2', text)
         return output
-    
+
     def fetch_page(self, url):
         "Used for fetching all the remote pages."
 
         self.message('Fetching: ' + url)
-        
+
         try:
             response = requests.get(url, timeout=10)
         except requests.exceptions.ConnectionError as e:
@@ -586,13 +728,13 @@ class GuardianGrabber:
             self.message("HTTP Error: %s" % response.status_code)
 
         return response.text
-    
+
     def count_words(self, text):
         self.LINE_SEPS = ['\n']
         self.WORD_SEPS = ['\s']
         self.REPEATER_SEPS = ['-']
         self.IGNORE = []
-        
+
         def ors(l): return r"|".join([re.escape(c) for c in l])
         def retext(text, chars, sub):
             return re.compile(ors(chars)).sub(sub, text)
@@ -604,7 +746,7 @@ class GuardianGrabber:
         words = text and len(re.compile(r"[ ]+").split(text)) or 0
 
         return (words, lines)
-        
+
     def message(self, text):
         "Output debugging info, if in verbose mode."
         if self.verbose:
@@ -613,13 +755,13 @@ class GuardianGrabber:
 
 class ScraperError(Exception):
     pass
-        
-        
+
+
 def main():
     scraper = GuardianGrabber()
-    
+
     scraper.start()
-    
+
 
 if __name__ == "__main__":
     main()

--- a/templates/article.html
+++ b/templates/article.html
@@ -1,4 +1,12 @@
-<div class="section-default tone-{{ article['tone'] }}">
+{# Do we show a contributor thumbnail or not? #}
+{% set has_contributor = False %}
+
+{% if article['sectionName'] == 'Opinion' and 'contributor' in article and article['contributor'] %}
+	{% set has_contributor = True %}
+{% endif %}
+
+
+<div class="section-default tone-{{ article['tone'] }}{% if has_contributor %} has-contributor{% endif %}">
 
 	<div class="meta">
 		{% if 'publication' in article['fields'] %}
@@ -22,22 +30,27 @@
 		</div>
 	{% endif %}
 
-	<div class="intro">
-		{% if 'byline' in article['fields'] %}
-			<p class="byline">
+	{% if 'byline' in article['fields'] %}
+		<div class="byline">
+			<p>
 				{{ article['fields']['byline']|typogrify }}
 			</p>
+		</div>
+	{% endif %}
+
+	<div class="body">
+		{% if has_contributor %}
+			<img class="thumbnail" src="{{ article['contributor']['bylineImageUrl'] }}" alt="Picture of {{ article['contributor']['webTitle'] }}">
 		{% endif %}
 
 		{% if 'standfirst' in article['fields'] %}
 			<p class="standfirst">
-				{{ article['fields']['standfirst']|typogrify }}
+				{# Remove p tags that are sometimes around this already. #}
+				{{ article['fields']['standfirst']|replace("<p>", "")|replace("</p>", "")|typogrify }}
 			</p>
 		{% endif %}
-	</div>
 
-	<div class="body">
-		{% if 'thumbnail' in article['fields'] %}
+		{% if not has_contributor and  'thumbnail' in article['fields'] %}
 			<img class="thumbnail" alt="Thumbnail image" src="{{ article['fields']['thumbnail'] }}">
 		{% endif %}
 

--- a/templates/article.html
+++ b/templates/article.html
@@ -1,4 +1,4 @@
-<div class="section-default">
+<div class="section-default tone-{{ article['tone'] }}">
 
 	<div class="meta">
 		{% if 'publication' in article['fields'] %}
@@ -9,7 +9,7 @@
 
 		{% if 'sectionName' in article %}
 			<p class="section">
-				{{ article['sectionName'] }}
+				{{ article['sectionName'] }} / {{ article['newspaperBookSection']['webTitle'] }} / {{ article['newspaperBookSection']['sectionName'] }}
 			</p>
 		{% endif %}
 	</div>

--- a/templates/article.html
+++ b/templates/article.html
@@ -1,7 +1,7 @@
 {# Do we show a contributor thumbnail or not? #}
 {% set has_contributor = False %}
 
-{% if article['sectionName'] == 'Opinion' and 'contributor' in article and article['contributor'] %}
+{% if article['sectionName'] == 'Opinion' and 'contributor' in article and article['contributor'] and 'bylineImageUrl' in article['contributor'] %}
 	{% set has_contributor = True %}
 {% endif %}
 

--- a/templates/article.html
+++ b/templates/article.html
@@ -1,0 +1,73 @@
+<div class="section-default">
+
+	<div class="meta">
+		{% if 'publication' in article['fields'] %}
+			<p class="publication">
+				{{ article['fields']['publication'] }}
+			</p>
+		{% endif %}
+
+		{% if 'sectionName' in article %}
+			<p class="section">
+				{{ article['sectionName'] }}
+			</p>
+		{% endif %}
+	</div>
+
+	{% if 'headline' in article['fields'] %}
+		<div class="headline">
+			<h2>
+				{{ article['fields']['headline']|typogrify }}
+			</h2>
+		</div>
+	{% endif %}
+
+	<div class="intro">
+		{% if 'byline' in article['fields'] %}
+			<p class="byline">
+				{{ article['fields']['byline']|typogrify }}
+			</p>
+		{% endif %}
+
+		{% if 'standfirst' in article['fields'] %}
+			<p class="standfirst">
+				{{ article['fields']['standfirst']|typogrify }}
+			</p>
+		{% endif %}
+	</div>
+
+	<div class="body">
+		{% if 'thumbnail' in article['fields'] %}
+			<img class="thumbnail" alt="Thumbnail image" src="{{ article['fields']['thumbnail'] }}">
+		{% endif %}
+
+		{% if 'body' in article['fields'] %}
+			{% if article['fields']['body'] == '<!-- Redistribution rights for this field are unavailable -->' %}
+				<p class="no-rights">Redistribution rights for the article body are unavailable. <a class="see-original" href="{{ article['webUrl'] }}/print?mobile-redirect=false">See original.</a></p>
+			{% else %}
+				{# Sometimes there are empty p tags. Remove them. #}
+				{{ article['fields']['body']|replace("<p></p>", "")|typogrify }}
+			{% endif %}
+		{% else %}
+			<p class="no-body">No body text available.</p>
+		{% endif %}
+	</div>
+
+	<div class="footer">
+		<p class="paper">
+			<span>Paper: </span>p.{{ article['fields']['newspaperPageNumber'] }} in {{ article['newspaperBook']['webTitle'] }}
+		</p>
+		{% if 'webUrl' in article %}
+			<p class="original">
+				<span>Web: </span><a href="{{ article['webUrl'] }}">{{ article['webUrl'] }}</a>
+			</p>
+		{% endif %}
+		{% if 'shortUrl' in article['fields'] %}
+			<p class="share">
+				<span>Share: </span><input type="text" value="{{ article['fields']['shortUrl'] }}">
+			</p>
+		{% endif %}
+
+	</div>
+
+</div>

--- a/templates/article.html
+++ b/templates/article.html
@@ -17,7 +17,7 @@
 
 		{% if 'sectionName' in article %}
 			<p class="section">
-				{{ article['sectionName'] }} / {{ article['newspaperBookSection']['webTitle'] }} / {{ article['newspaperBookSection']['sectionName'] }}
+				{{ article['sectionName'] }}
 			</p>
 		{% endif %}
 	</div>


### PR DESCRIPTION
Stop scraping web pages and use only the API. Now, instead of scraping a page and downloading each article from the API individually we can get the whole paper in a single API request (or maybe two for an unusually big issue). The articles are then sorted by their `newspaper-book` tag, and within those by their `newspaperPageNumber` field.

Some other tweaks to things like:

* Using Jinja2 for templating.
* Using typogrify for text niceties.
* Showing byline photos for Opinion articles that have byline photos.
* Making the colours of headings consistent with the current Guardian site's `tone` colours.